### PR TITLE
jmp with decimal value not working recently

### DIFF
--- a/core/arch.py
+++ b/core/arch.py
@@ -40,8 +40,8 @@ class x86(Arch):
     _cs = CS_ARCH_X86, CS_MODE_32
     _ks = KS_ARCH_X86, KS_MODE_32
 
-    def call(self, dst): return 'call %s;' % dst
-    def jmp(self, dst):  return 'jmp %s;' % dst
+    def call(self, dst): return 'call 0x%x;' % dst
+    def jmp(self, dst):  return 'jmp 0x%x;' % dst
 
     def ret(self): return 'ret;'
     def nop(self): return 'nop;'


### PR DESCRIPTION
assembler not generate correct instructions for `jmp` and `call` with decimal value.
```python
# This will ends up with patch is not aligned warning
pt.patch(old, jmp=new)
```
