### PR TITLE
Correct deps.sh for new unicorn version

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -6,7 +6,7 @@ echo " https://github.com/unicorn-engine/unicorn/blob/master/docs/COMPILE-NIX.md
 echo
 echo "If you're on Ubuntu, you want to do this first:"
 echo " sudo apt-get update"
-echo " sudo apt-get install python-pip build-essential git cmake python-dev libglib2.0-dev"
+echo " sudo apt-get install python3-pip python-is-python3 build-essential git cmake python-dev libglib2.0-dev"
 echo
 echo "If you're on a Mac, do this first:"
 echo " brew install pkg-config glib cmake"
@@ -39,7 +39,10 @@ echo
 echo "[*] Building Unicorn"
 cd "$build"
 git clone https://github.com/unicorn-engine/unicorn.git
-cd unicorn && ./make.sh
+cd unicorn && \
+mkdir build; cd build && \
+cmake .. -DCMAKE_BUILD_TYPE=Release && \
+make
 
 echo
 echo "[*] Installing projects and Python bindings (using sudo)"
@@ -49,7 +52,7 @@ cd "$build/keystone/bindings/python" && sudo make install
 cd "$build/capstone" && sudo make install
 cd "$build/capstone/bindings/python" && sudo make install
 
-cd "$build/unicorn" && sudo ./make.sh install
+cd "$build/unicorn/build" && sudo make install
 cd "$build/unicorn/bindings/python" && sudo make install
 
 which ldconfig &>/dev/null && sudo ldconfig

--- a/deps.sh
+++ b/deps.sh
@@ -61,4 +61,4 @@ echo
 echo "All done!"
 echo
 echo -n "Testing Python import: "
-python -c "import capstone, keystone, unicorn; capstone.CS_ARCH_X86, unicorn.UC_ARCH_X86, keystone.KS_ARCH_X86; print 'works.'"
+python -c "import capstone, keystone, unicorn; capstone.CS_ARCH_X86, unicorn.UC_ARCH_X86, keystone.KS_ARCH_X86; print('works.')"


### PR DESCRIPTION
New unicorn removed make.sh file.
Ubuntu 20 need to install python3-pip python-is-python3 instead of python-pip