### PR TITLE
Fix unknow LOAD key 0x6474E553 (KeyError: 1685382483)

### DIFF
--- a/util/elffile.py
+++ b/util/elffile.py
@@ -63,7 +63,11 @@ class Coding(object):
         if isinstance(key, basestring):
             return self.byname[key]
         elif isinstance(key, int):
-            return self.bycode[key]
+            try:
+                return self.bycode[key]
+            except:
+                print('Unknow key', key)
+                return Code(self, '', 0, '')
         else:
             raise KeyError(key)
 


### PR DESCRIPTION
Some application compiled by GCC 9 generated LOAD key which patchkit not yet supported, I am not sure what kind of that key but I ignored and it works.