### PR TITLE
Create autoApplyPatch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "*.pyc": true
+    },
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,6 +57,25 @@
                 "kind": "build",
                 "isDefault": false
             }
-        }
+        },
+        {
+            "label": "Check git status",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && git status",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "Check git diff",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && git difftool",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,62 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [        
+        {
+            "label": "Patch current file",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && patchkit battle ${file} -v",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": []
+        },        
+        {
+            "label": "Upload to dev",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && ssh root@10.9.1.60 'killall -9 supervisor.battle battle'; scp ./battle.patched 10.9.1.60://home/pirate/battle/bin/battle",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "Upload to dev 2",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && ssh root@10.9.1.61 'killall -9 supervisor.battle battle'; scp ./battle.patched 10.9.1.61://home/pirate/battle/bin/battle",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "Upload to local 1",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && ssh -p 3232 root@10.18.24.92 'killall -9 supervisor.battle battle'; scp -P 3232 ./battle.patched 10.18.24.92://home/pirate/battle/bin/battle",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "Upload to local 2",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && ssh -p 3232 root@10.18.24.75 'killall -9 supervisor.battle battle'; scp -P 3232 ./battle.patched 10.18.24.75://home/pirate/battle/bin/battle",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "z. Patch all",
+            "type": "shell",
+            "command": "cd /home/duongtc/568E/Haitac/ep01-patching/patchkit && patchkit battle patch_script/",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
+- This function support 0xBeginOfBlock variable inside the ASM code:
+```python
+    newAsm = """
+    add r12, 1
+    add eax, 1
+    cmp eax, 5
+    jl 0xBeginOfBlock          # Loop this block until rax >= 5
+    xor eax, eax
+    add edx, 1
+    cmp edx, 5
+    jl 0xBeginOfBlock          # Loop this block until edx >= 5
+    """
+    pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
+```
+Assume eax, edx and r12 is zero at beginning, the result of above code is r12 = 25
 - This function support postAsm parametter:
     + This is a special ASM which ALWAYS be excuted after the new inserted ASM, just before it jump out
     + You should use it when have more than one break jump in your new ASM code

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Note: I fixed some bug and add new features:
+- autoApplyPatch: auto apply a new patch into an address (this is a combination of inject, patch and hook)
+- autoReplaceString: auto replace a string data
+- checksize: return the binary size of a set of ASM
+- genNop: generate X number of nop command
+
 patchkit
 ----
 Patches an ELF binary using one or more simple Python scripts.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Contains one or more Python patch files, which will be executed in alphabetical 
 Patch Examples
 ----
 
-autoApplyPatch:
+autoApplyPatch: Auto replace the original ASM code by a new asm code. You just need to call this function then it will take care everything for you.
 ```python
 
     def simple_patch(pt):

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
 - This function support postAsm parametter:
-    + This is a special ASM which ALWAYS be excute after the new ASM inserted, just before jmp out
+    + This is a special ASM which ALWAYS be excuted after the new ASM inserted, just before jmp out
     + You should use this when have more than one break jump in your new ASM code
     + It only be executed with jump to 0xReturnAddress and end of script. If you have any other jump instruction, that code won't execute
     + Example: below code with push rax at beginning and it will always execute the pop rax when finish

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
-- This function support 0xReturnAddress variable:
+- This function support 0xReturnAddress variable inside the ASM code:
 ```python
     newAsm = """
     mov rax, rdi
@@ -50,6 +50,34 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     sub ebx, 1
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
+```
+- This function support postAsm parametter:
+    + This is a special ASM which ALWAYS be excute after the new ASM inserted, just before jmp out
+    + You should use this when have more than one break jump in your new ASM code
+    + It only be executed with jump to 0xReturnAddress and end of script. If you have any other jump instruction, that code won't execute
+    + Example: below code with push rax at beginning and it will always execute the pop rax when finish
+```python
+    postAsm = """
+    pop     rax             #restore rax
+    """
+    
+    newAsm = """
+    push    rax             #backup rax
+    
+    mov rax, rdi
+    test rax, rax
+    jz 0xReturnAddress         
+    test esi, esi
+    jnz 0xReturnAddress
+    mov ebx, esi
+    xor rax, rax    
+    
+    test ebx, ebx
+    jz 0x12345              #WARNING: This jump instuction won't execute the postAsm, so some time it will cause error, such as this case it's missing a POP command
+    
+    sub ebx, 1
+    """
+    pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, postAsm=postAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
 
 checksize: return the code size for a/a set of instruction(s)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Patch Examples
 ----
 
 autoApplyPatch:
+```python
 
     def simple_patch(pt):
         pt.autoApplyPatch(addr = 0x1182, newAsm="mov rax, rdi; mov ebx, esi", oldAsm="mov eax, edi; mov ebx, esi", desc="")
-
+```
 - Enough code space for the patch: If the old code size is BIGGER or EQUAL than the new code size: patch directly, nop command will be used to fill for the rest, a jmp also be added incase we have too many nop command.
 - Not enough code space for the patch: If the old code size is SMALLER than the new code size:
     + Create the new inject code with jmp to return to the next original instruction automatically.
@@ -27,6 +28,7 @@ autoApplyPatch:
         * If the old code size is BIGGER or EQUAL than the jmp code size: patch the jum then finish this patch.
         * If the old code size is SMALLER than the new jmp size: show error and skip this patch, the new injected code still be keep, so you can create the jmp by yourself later.
 - This function support comment on the asm code:
+```python
     newAsm = """
     # whole line comment
     mov rax, rdi                # this is comment
@@ -34,32 +36,38 @@ autoApplyPatch:
     xor rax, rax; sub ebx, 1;   # this style also be accepted
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
+```
 - This function support 0xReturnAddress variable:
+```python
     newAsm = """
     mov rax, rdi
     test rax, rax
-    jz 0xReturnAddress          # Check and ignore the rest of custom asm code,
+    jz 0xReturnAddress          # Check and ignore the rest of custom asm code
     test esi, esi
-    jnz 0xReturnAddress         # Check and ignore the rest of custom asm code,
+    jnz 0xReturnAddress         # Check and ignore the rest of custom asm code
     mov ebx, esi
     xor rax, rax
     sub ebx, 1
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
-
+```
 
 checksize: return the code size for a/a set of instruction(s)
 
+```python
+
     def simple_patch(pt):
         codeSize = pt.checksize(addr = 0x1182, asm="mov rax, rdi; mov ebx, esi", is_asm=True)
-
+```
 genNop: return the number of nop instruction(s)
+```python
 
     def simple_patch(pt):
         asm = genNop(3)
         #asm is now "nop;nop;nop;"
-
+```
 Nopping an address, injecting an assembly function, and hooking the entry point:
+```python
 
     def simple_patch(pt):
         # nop out a jump at the entry point
@@ -70,8 +78,9 @@ Nopping an address, injecting an assembly function, and hooking the entry point:
 
         # hook the entry point to make it call addr (ret will run the original entry point)
         pt.hook(pt.entry, addr)
-
+```
 Replacing a C function:
+```python
 
     def replace_free(pt):
         # pretend free() is at this address:
@@ -86,7 +95,7 @@ Replacing a C function:
 
         # patch the beginning of free() with a jump to our new function
         pt.patch(old_free, jmp=new_free)
-
+```
 
 API
 ----
@@ -122,6 +131,7 @@ These are somewhat CGC and x86-specific right now, but will be ported for genera
 
 Dependencies
 ----
+- Python 2
 - Run `./deps.sh` to automatically install these.
   - Capstone Engine - https://github.com/aquynh/capstone.git
   - Keystone Engine - https://github.com/keystone-engine/keystone.git

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ Contains one or more Python patch files, which will be executed in alphabetical 
 Patch Examples
 ----
 
+autoApplyPatch:
+
+    def simple_patch(pt):
+        pt.autoApplyPatch(addr = 0x1182, newAsm="mov rax, rdi; mov ebx, esi", oldAsm="mov eax, edi; mov ebx, esi", desc="")
+
+- Enough code space for the patch: If the old code size is BIGGER or EQUAL than the new code size: patch directly
+- Not enough code space for the patch: If the old code size is SMALLER than the new code size:
+    + Create the new inject code with jmp to return to the next original instruction automatically.
+    + Create the new jmp instruction to jump to the new injected code.
+        * If the old code size is BIGGER or EQUAL than the jmp code size: patch the jum then finish this patch.
+        * If the old code size is SMALLER than the new jmp size: show error and skip this patch, the new injected code still be keep, so you can create the jmp by yourself later.
+
+
+checksize: return the code size for a/a set of instruction(s)
+
+    def simple_patch(pt):
+        codeSize = pt.checksize(addr = 0x1182, asm="mov rax, rdi; mov ebx, esi", is_asm=True)
+
+genNop: return the number of nop instruction(s)
+
+    def simple_patch(pt):
+        asm = genNop(3)
+        #asm is now "nop;nop;nop;"
+
 Nopping an address, injecting an assembly function, and hooking the entry point:
 
     def simple_patch(pt):

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, postAsm=postAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
 
+autoReplaceString: auto replace a string data
+```python
+
+    def simple_patch(pt):
+        pt.autoReplaceString(0x4D5110, newStr = "I hate Apple", oldStr="This is an apple", desc="Apply new text and fill zero for the rest")
+        
+        pt.autoReplaceString(0x4D5110, newStr = "This is an apple", oldStr="I hate Apple", desc="This action will be ignored because the old text is too short")
+```
+
+
 checksize: return the code size for a/a set of instruction(s)
 
 ```python
@@ -132,6 +142,7 @@ API
     patch(addr, *compile arg*)
     addr = inject(*compile arg*)
     autoApplyPatch
+    autoReplaceString
     checksize
     genNop
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ API
     hook(addr, new_addr)
     patch(addr, *compile arg*)
     addr = inject(*compile arg*)
+    autoApplyPatch
+    checksize
+    genNop
 
     *compile arg* is any of the following:
       raw='data'

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```
 - This function support postAsm parametter:
-    + This is a special ASM which ALWAYS be excuted after the new ASM inserted, just before jmp out
-    + You should use this when have more than one break jump in your new ASM code
+    + This is a special ASM which ALWAYS be excuted after the new inserted ASM, just before it jump out
+    + You should use it when have more than one break jump in your new ASM code
     + It only be executed with jump to 0xReturnAddress and end of script. If you have any other jump instruction, that code won't execute
     + Example: below code with push rax at beginning and it will always execute the pop rax when finish
 ```python
@@ -66,16 +66,19 @@ autoApplyPatch: Auto replace the original ASM code by a new asm code. You just n
     
     mov rax, rdi
     test rax, rax
-    jz 0xReturnAddress         
+    jz 0xReturnAddress      #this will jump to the postAsm
     test esi, esi
-    jnz 0xReturnAddress
+    jnz 0xReturnAddress     #this will jump to the postAsm
     mov ebx, esi
     xor rax, rax    
     
     test ebx, ebx
-    jz 0x12345              #WARNING: This jump instuction won't execute the postAsm, so some time it will cause error, such as this case it's missing a POP command
+    jz 0x12345              # WARNING: This jump instuction won't execute the postAsm, 
+                            # so some time it will cause error, 
+                            # such as this case it's missing a POP command
     
     sub ebx, 1
+                            #new jmp to the postAsm will be inserted here
     """
     pt.autoApplyPatch(addr = 0x1182, newAsm=newAsm, postAsm=postAsm, oldAsm="mov eax, edi; mov ebx, esi", desc="")
 ```

--- a/core/context.py
+++ b/core/context.py
@@ -393,6 +393,7 @@ class Context(object):
         realNextAddress = nextAddress = addr + oldSize
 
         if len(postAsm) > 0:
+            postAsm = postAsm.replace("0xRealReturnAddress", "0x%x" % realNextAddress)
             nextAddress = self.inject(asm=postAsm + "\njmp 0x%x" % nextAddress , desc = 'post-asm | "%s"' % desc, retWarn = False)
 
         newAsm = newAsm.replace("0xReturnAddress", "0x%x" % nextAddress)

--- a/core/context.py
+++ b/core/context.py
@@ -343,6 +343,24 @@ class Context(object):
         raw, typ = self._compile(addr, **kwargs)
         return len(raw)
 
+    def autoReplaceString(self, addr, **kwargs):
+        newStr = kwargs.get('newStr', "")
+        oldStr = kwargs.get('oldStr', "")
+        desc = kwargs.get('desc', '')
+
+        if (len(newStr) > len(oldStr) and len(oldStr) > 0):
+            self.error(hex(addr) + " " + desc + " new string is too long.")
+            return
+
+        if len(oldStr) > len(newStr):
+            string_val = "\0" * (len(oldStr) - len(newStr)) * 2
+            newStr = newStr + string_val
+
+        hnewStr = "".join([hex(ord(x)) for x in newStr]).replace("0x", "")
+
+        self.patch(addr, hex=hnewStr, desc=desc)        
+
+
     def autoApplyPatch(self, addr, **kwargs):
         #addr = kwargs.get('addr', '')
         newAsm = kwargs.get('newAsm', "").rstrip().lstrip()

--- a/core/context.py
+++ b/core/context.py
@@ -345,8 +345,9 @@ class Context(object):
 
     def autoApplyPatch(self, addr, **kwargs):
         #addr = kwargs.get('addr', '')
-        newAsm = kwargs.get('newAsm', False).rstrip().lstrip()
-        oldAsm = kwargs.get('oldAsm', False).rstrip().lstrip()
+        newAsm = kwargs.get('newAsm', "").rstrip().lstrip()
+        oldAsm = kwargs.get('oldAsm', "").rstrip().lstrip()
+        postAsm = kwargs.get('postAsm', "").rstrip().lstrip()
         desc = kwargs.get('desc', '')
         checkDep = kwargs.get('checkDep', False)
         ijAddr = kwargs.get('ijAddr', 0)
@@ -364,7 +365,7 @@ class Context(object):
 
         lastNewAsm = lastNewAsm.split(" ")
 
-        needAddJump = (lastNewAsm[0].lower() !="jmp")
+        needAddJump = (lastNewAsm[0].lower() !="jmp" and lastNewAsm[0].lower() !="ret")
 
         if not checkDep:
             self.info("")
@@ -372,6 +373,9 @@ class Context(object):
         oldSize = self.checksize(addr, asm=oldAsm, is_asm=True)
 
         nextAddress = addr + oldSize
+
+        if len(postAsm) > 0:
+            nextAddress = self.inject(asm=postAsm + "\njmp 0x%x" % nextAddress , desc = 'post-asm | "%s"' % desc, retWarn = False)
 
         newAsm = newAsm.replace("0xReturnAddress", "0x%x" % nextAddress)
 

--- a/core/context.py
+++ b/core/context.py
@@ -344,7 +344,7 @@ class Context(object):
         if typ == 'asm' or kwargs.get('is_asm'):
             size = len(''.join([str(i.bytes) for i in self.dis(addr, len(raw))]))
             if size != len(raw) and not kwargs.get('internal'):
-                self.warn('Assembly patch is not aligned with underlying instructions.')
+                self.warn('Assembly patch is not aligned with underlying instructions. size = ' + str(size) + " raw = " + str(len(raw)) + " addr " + hex(addr))
 
         self._lint(addr, raw, typ, is_asm=kwargs.get('is_asm'))
         if not kwargs.get('silent'):

--- a/core/context.py
+++ b/core/context.py
@@ -331,7 +331,7 @@ class Context(object):
         else:
             return addr
 
-    def genNop(number):
+    def genNop(self, number):
         if not isinstance(number, int):
             return
         ret = ""
@@ -361,14 +361,16 @@ class Context(object):
             self.patch(addr, asm=newAsm, is_asm=True, desc = desc)
             return 0
         elif oldSize > newSize:
-            self.patch(addr, asm=newAsm, is_asm=True, desc = desc)
-            return addr + newSize + 1
+            if checkDep:
+                self.patch(addr, asm=newAsm, is_asm=True, desc = desc)
+                return addr + newSize + 1
+            self.patch(addr, asm=newAsm + ";" + self.genNop(oldSize - newSize), is_asm=True, desc = desc)
         else: #newSize > oldSize: not enough space to insert
             if checkDep:
                 self.error(hex(addr) + " Cannot create jump:\"" + newAsm + "\" (" + str(newSize) + " byte) to replace \"" + oldAsm + "\" (" + str(oldSize) + " byte)")
                 return
 
-            self.warn(hex(addr) + " Cannot replace \"" + oldAsm + "\" (" + str(oldSize) + " byte) by \"" + newAsm + "\" (" + str(newSize) + " byte), injecting code.")
+            self.warn(hex(addr) + " Code space is " + str(oldSize) + " byte, new code need " + str(newSize) + " byte, injecting mode")
 
             ijAddr = self.inject(asm=newAsm + "; jmp 0x%x" % (addr + oldSize), desc = desc, retWarn = False)
 

--- a/core/context.py
+++ b/core/context.py
@@ -398,6 +398,7 @@ class Context(object):
 
         newAsm = newAsm.replace("0xReturnAddress", "0x%x" % nextAddress)
         newAsm = newAsm.replace("0xRealReturnAddress", "0x%x" % realNextAddress)
+        newAsm = newAsm.replace("0xBeginOfBlock", "0x%x" % addr)
 
         newSize = self.checksize(addr, asm=newAsm, is_asm=True)
 

--- a/core/patcher.py
+++ b/core/patcher.py
@@ -63,7 +63,7 @@ class Patcher:
                         continue
 
                     if hasattr(func, '__call__'):
-                        self.debug(' [+] %s()' % func.__name__)
+                        self.debug('\n [+] %s()' % func.__name__)
                         with self.bin.collect() as patchset:
                             try:
                                 func(patchset)

--- a/deps_install.sh
+++ b/deps_install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -u
 
+
+
 echo
 echo "Take a look here if Unicorn fails to build:"
 echo " https://github.com/unicorn-engine/unicorn/blob/master/docs/COMPILE-NIX.md"
@@ -19,54 +21,24 @@ echo
 
 cwd=$(pwd)
 build="$cwd/build"
-
-mkdir -p build &>/dev/null
-
-echo "[*] Clone code"
-echo "[*] Clone Keystone"
-cd "$build"
-git clone https://github.com/keystone-engine/keystone.git
-echo
-
-echo "[*] Clone Capstone"
-cd "$build"
-git clone https://github.com/aquynh/capstone.git
-echo
-
-echo "[*] Clone Unicorn"
-cd "$build"
-git clone https://github.com/unicorn-engine/unicorn.git
-
-
 set -e
-
-echo "[*] Building Keystone"
-cd "$build"
-cd keystone && mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD="all" -G "Unix Makefiles" .. && make -j2
-echo
-
-echo "[*] Building Capstone"
-cd "$build"
-cd capstone && make -j2
-echo
-
-echo "[*] Building Unicorn"
-cd "$build"
-cd unicorn #&& ./make.sh
-mkdir -p build; cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
 
 echo
 echo "[*] Installing projects and Python bindings (using sudo)"
+
+echo "[*] Installing keystone"
 cd "$build/keystone/build" && sudo make install
+echo "[*] Bindings keystone python"
 cd "$build/keystone/bindings/python" && sudo make install
 
+echo "[*] Installing capstone"
 cd "$build/capstone" && sudo make install
+echo "[*] Bindings capstone python"
 cd "$build/capstone/bindings/python" && sudo make install
 
-cd "$build/unicorn/build/build" && sudo make install
+echo "[*] Installing unicorn"
+cd "$build/unicorn/build/build" && sudo make installwwwwwwdww
+echo "[*] Bindings unicorn python"
 cd "$build/unicorn/bindings/python" && sudo make install
 
 which ldconfig &>/dev/null && sudo ldconfig

--- a/util/elffile.py
+++ b/util/elffile.py
@@ -63,7 +63,13 @@ class Coding(object):
         if isinstance(key, basestring):
             return self.byname[key]
         elif isinstance(key, int):
-            return self.bycode[key]
+            #Fix unknow LOAD key 0x6474E553 (KeyError: 1685382483)
+            #Some application compiled by GCC 9 generated LOAD key which patchkit not yet supported, I am not sure what kind of that key but I ignored and it works.
+            try: 
+                return self.bycode[key]
+            except:
+                print('Unknow key', key)
+                return Code(self, '', 0, '')
         else:
             raise KeyError(key)
 
@@ -446,6 +452,7 @@ PT('PT_LOOS', 0x60000000, '')
 PT('PT_GNU_EH_FRAME', 0x6474e550, 'GCC .eh_frame_hdr segment')
 PT('PT_GNU_STACK', 0x6474e551, 'Indicates stack executability')
 PT('PT_GNU_RELRO', 0x6474e552, 'Read only after relocation')
+PT('PT_GNU_PROPERTY', 0x6474e553, 'Describes the .note.gnu.property section')
 PT('PT_LOSUNW', 0x6ffffffa, '')
 PT('PT_SUNWBSS', 0x6ffffffa, 'Sun Specific segment')
 PT('PT_SUNWSTACK', 0x6ffffffb, 'Stack segment')


### PR DESCRIPTION
autoApplyPatch will auto select patch directly or create new injected code depend on the code size:


autoApplyPatch:

    def simple_patch(pt):
        pt.autoApplyPatch(addr = 0x1182, newAsm="mov rax, rdi; mov ebx, esi", oldAsm="mov eax, edi; mov ebx, esi", desc="")

- Enough code space for the patch: If the old code size is BIGGER or EQUAL than the new code size: patch directly
- Not enough code space for the patch: If the old code size is SMALLER than the new code size:
    + Create the new inject code with jmp to return to the next original instruction automatically.
    + Create the new jmp instruction to jump to the new injected code.
        * If the old code size is BIGGER or EQUAL than the jmp code size: patch the jum then finish this patch.
        * If the old code size is SMALLER than the new jmp size: show error and skip this patch, the new injected code still be keep, so you can create the jmp by yourself later.
